### PR TITLE
Correction Model is from Bart-Base, not BART-large

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The goal of this project is to reproduce Table 3 of [Chen et al's paper](https:/
 
 ## Introduction
 
-The authors present a method for correcting hallucinations in generated text summaries. They leverage a pre-trained BART-large model which is fine-tuned to discriminate between "faithful" and "unfaithful" summaries. The training data for fine-tuning is created by artificially corrupting ground truth (human created) summaries. 
+The authors present a method for correcting hallucinations in generated text summaries. They leverage a pre-trained BART-Base model which is fine-tuned to discriminate between "faithful" and "unfaithful" summaries. The training data for fine-tuning is created by artificially corrupting ground truth (human created) summaries. 
 
 At a high-level, the process can be broken down into two steps:
 


### PR DESCRIPTION
> For our contrast candidate selection model, we use
a pretrained BART base model. We add a linear
layer over the max pooled embedding, and the classification model is expected to output a label between ["FAITHFUL", "HALLUCINATED"].
For all our experiments, we use the following set
of hyper-parameters: r = 1e − 5, margin γ = 0,
number of training epoch= 3.